### PR TITLE
add implementation for actuator' db metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     testCompile "org.projectlombok:lombok:1.18.4",
                 "org.springframework.boot:spring-boot-starter-test:1.5.17.RELEASE",
+                "org.springframework.boot:spring-boot-starter-web:1.5.17.RELEASE",
                 "org.codehaus.groovy:groovy-all:2.5.4",
                 "org.testcontainers:mariadb:1.10.1",
                 "org.mariadb.jdbc:mariadb-java-client:2.3.0",

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
             "org.springframework.boot:spring-boot-configuration-processor:1.5.17.RELEASE"
 
     compile "org.springframework.boot:spring-boot-starter-jdbc:1.5.17.RELEASE",
+            "org.springframework.boot:spring-boot-actuator:1.5.17.RELEASE",
             "com.zaxxer:HikariCP:3.2.0"
 
     testCompile "org.projectlombok:lombok:1.18.4",

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ dependencies {
 
     compile "org.springframework.boot:spring-boot-starter-jdbc:1.5.17.RELEASE",
             "org.springframework.boot:spring-boot-actuator:1.5.17.RELEASE",
-            "com.zaxxer:HikariCP:3.2.0"
+            "com.zaxxer:HikariCP:3.2.0",
+            "org.apache.commons:commons-lang3:3.8"
 
     testCompile "org.projectlombok:lombok:1.18.4",
                 "org.springframework.boot:spring-boot-starter-test:1.5.17.RELEASE",

--- a/src/main/java/io/ankburov/spring/balancing/datasource/config/BalancingDataSourceConfiguration.java
+++ b/src/main/java/io/ankburov/spring/balancing/datasource/config/BalancingDataSourceConfiguration.java
@@ -19,6 +19,7 @@ import io.ankburov.spring.balancing.datasource.log.TimedFailedDataSourceLogStrat
 import io.ankburov.spring.balancing.datasource.metadata.HikariBalancingDataSourcePublicMetrics;
 import io.ankburov.spring.balancing.datasource.property.BalancingDataSourceProperties;
 import org.springframework.boot.actuate.endpoint.DataSourcePublicMetrics;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -104,7 +105,7 @@ public class BalancingDataSourceConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "spring.balancing-config.balancing", value = "enableMetricsForDB", havingValue = "hikari")
+    @ConditionalOnExpression("'${spring.balancing-config.connectionPoolType}' == 'hikari' && !${spring.balancing-config.balancing.overrideBalancingDataSource:false}")
     public DataSourcePublicMetrics hikariBalancingDataSourcePublicMetrics(BalancingDataSource balancingDataSource) {
         return new HikariBalancingDataSourcePublicMetrics(balancingDataSource);
     }

--- a/src/main/java/io/ankburov/spring/balancing/datasource/config/BalancingDataSourceConfiguration.java
+++ b/src/main/java/io/ankburov/spring/balancing/datasource/config/BalancingDataSourceConfiguration.java
@@ -16,8 +16,9 @@ import io.ankburov.spring.balancing.datasource.ignore.IgnoreDataSourceByUrlStrat
 import io.ankburov.spring.balancing.datasource.ignore.IgnoreDataSourceStrategy;
 import io.ankburov.spring.balancing.datasource.log.FailedDataSourceLogStrategy;
 import io.ankburov.spring.balancing.datasource.log.TimedFailedDataSourceLogStrategy;
-import io.ankburov.spring.balancing.datasource.metadata.BalancingDataSourcePublicMetrics;
+import io.ankburov.spring.balancing.datasource.metadata.HikariBalancingDataSourcePublicMetrics;
 import io.ankburov.spring.balancing.datasource.property.BalancingDataSourceProperties;
+import org.springframework.boot.actuate.endpoint.DataSourcePublicMetrics;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -79,12 +80,6 @@ public class BalancingDataSourceConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public BalancingDataSourcePublicMetrics balancingDataSourcePublicMetrics(BalancingDataSource balancingDataSource) {
-        return new BalancingDataSourcePublicMetrics(balancingDataSource);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
     public UpdateFailedDataSourceStrategy alwaysUpdateFailedDataSourceStrategy() {
         return new AlwaysUpdateFailedDataSourceStrategy();
     }
@@ -106,5 +101,11 @@ public class BalancingDataSourceConfiguration {
                                  UpdateFailedDataSourceStrategy updateFailedDataSourceStrategy) {
         return new BalancingDataSource(ignoreDataSourceStrategy, dataSourceFactory, properties, filteringStrategy, balancingStrategy,
                                        failedDataSourceLogStrategy, updateFailedDataSourceStrategy);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.balancing-config.balancing", value = "enableMetricsForDB", havingValue = "hikari")
+    public DataSourcePublicMetrics hikariBalancingDataSourcePublicMetrics(BalancingDataSource balancingDataSource) {
+        return new HikariBalancingDataSourcePublicMetrics(balancingDataSource);
     }
 }

--- a/src/main/java/io/ankburov/spring/balancing/datasource/config/BalancingDataSourceConfiguration.java
+++ b/src/main/java/io/ankburov/spring/balancing/datasource/config/BalancingDataSourceConfiguration.java
@@ -2,9 +2,9 @@ package io.ankburov.spring.balancing.datasource.config;
 
 import io.ankburov.spring.balancing.datasource.BalancingDataSource;
 import io.ankburov.spring.balancing.datasource.balancingtype.BalancingStrategy;
+import io.ankburov.spring.balancing.datasource.balancingtype.FailOverBalancingStrategy;
 import io.ankburov.spring.balancing.datasource.balancingtype.MostHealthyFirstBalancingStrategy;
 import io.ankburov.spring.balancing.datasource.balancingtype.RandomBalancingStrategy;
-import io.ankburov.spring.balancing.datasource.balancingtype.FailOverBalancingStrategy;
 import io.ankburov.spring.balancing.datasource.factory.DataSourceFactory;
 import io.ankburov.spring.balancing.datasource.factory.HikariDataSourceFactory;
 import io.ankburov.spring.balancing.datasource.failed.AlwaysUpdateFailedDataSourceStrategy;
@@ -16,6 +16,7 @@ import io.ankburov.spring.balancing.datasource.ignore.IgnoreDataSourceByUrlStrat
 import io.ankburov.spring.balancing.datasource.ignore.IgnoreDataSourceStrategy;
 import io.ankburov.spring.balancing.datasource.log.FailedDataSourceLogStrategy;
 import io.ankburov.spring.balancing.datasource.log.TimedFailedDataSourceLogStrategy;
+import io.ankburov.spring.balancing.datasource.metadata.BalancingDataSourcePublicMetrics;
 import io.ankburov.spring.balancing.datasource.property.BalancingDataSourceProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -74,6 +75,12 @@ public class BalancingDataSourceConfiguration {
     @ConditionalOnMissingBean
     public FailedDataSourceLogStrategy timedFailedDataSourceLogStrategy(BalancingDataSourceProperties properties) {
         return new TimedFailedDataSourceLogStrategy(properties.getLogging().getTimeThreshold());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public BalancingDataSourcePublicMetrics balancingDataSourcePublicMetrics(BalancingDataSource balancingDataSource) {
+        return new BalancingDataSourcePublicMetrics(balancingDataSource);
     }
 
     @Bean

--- a/src/main/java/io/ankburov/spring/balancing/datasource/metadata/BalancingDataSourcePublicMetrics.java
+++ b/src/main/java/io/ankburov/spring/balancing/datasource/metadata/BalancingDataSourcePublicMetrics.java
@@ -1,0 +1,68 @@
+package io.ankburov.spring.balancing.datasource.metadata;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.ankburov.spring.balancing.datasource.BalancingDataSource;
+import io.ankburov.spring.balancing.datasource.model.NamedFailAwareDataSource;
+import javafx.util.Pair;
+import lombok.Getter;
+import org.springframework.boot.actuate.endpoint.DataSourcePublicMetrics;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.boot.autoconfigure.jdbc.metadata.HikariDataSourcePoolMetadata;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Class provides balancing-datasource specific implementation of Hikari Pool usage statistics.
+ * This statistics available at actuator' /metrics endpoint and provides 2 values - count and usage of DB Pool.
+ * Each of balanced DB has key prefix 'datasource.%dbName here%.', for ex. 'datasource.maindb.usage: 0.0'
+ * @author arxmim
+ * created 2019-01-28
+ */
+public class BalancingDataSourcePublicMetrics extends DataSourcePublicMetrics {
+
+    @Getter
+    private DataSourcePublicMetrics dataSourcePublicMetrics = new DataSourcePublicMetrics();
+
+    private final BalancingDataSource balancingDataSource;
+
+    public BalancingDataSourcePublicMetrics(BalancingDataSource balancingDataSource) {
+        this.balancingDataSource = balancingDataSource;
+    }
+
+    /**
+     * Actual list of metrics for DB. It invokes basic implementation (if any) and add balancing-datasource specific implementation, based on fact that
+     * spring-initialized javax.sql.Datasource (io.ankburov.spring.balancing.datasource.BalancingDataSource) actually contains list of manually created Hikari datasources.
+     * @return
+     */
+    @Override
+    public Collection<Metric<?>> metrics() {
+        Collection<Metric<?>> result = dataSourcePublicMetrics.metrics();
+        result.addAll(balancingDataSource.getDataSources()
+                                         .stream()
+                                         .map(this::splitToNameAndPoolMetadata)
+                                         .map(this::getMetricsFromDataSourcePoolMetadata)
+                                         .flatMap(Collection::stream)
+                                         .collect(Collectors.toList()));
+        return result;
+    }
+
+    private Pair<String, HikariDataSourcePoolMetadata> splitToNameAndPoolMetadata(NamedFailAwareDataSource namedFailAwareDataSource) {
+        HikariDataSourcePoolMetadata poolMetadata = Optional.of(namedFailAwareDataSource)
+                                                            .map(NamedFailAwareDataSource::getDataSource)
+                                                            .map(HikariDataSource.class::cast)
+                                                            .map(HikariDataSourcePoolMetadata::new)
+                                                            .orElseThrow(IllegalStateException::new);
+        return new Pair<>(namedFailAwareDataSource.getName(), poolMetadata);
+    }
+
+    private Collection<Metric<?>> getMetricsFromDataSourcePoolMetadata(Pair<String, HikariDataSourcePoolMetadata> hikariDataSourcePair) {
+        ArrayList<Metric<?>> list = new ArrayList<>();
+        String prefix = "datasource." + hikariDataSourcePair.getKey() + ".";
+        list.add(new Metric<>(prefix + "active", hikariDataSourcePair.getValue().getActive()));
+        list.add(new Metric<>(prefix + "usage", hikariDataSourcePair.getValue().getUsage()));
+        return list;
+    }
+}

--- a/src/main/java/io/ankburov/spring/balancing/datasource/metadata/HikariBalancingDataSourcePublicMetrics.java
+++ b/src/main/java/io/ankburov/spring/balancing/datasource/metadata/HikariBalancingDataSourcePublicMetrics.java
@@ -21,14 +21,14 @@ import java.util.stream.Collectors;
  * @author arxmim
  * created 2019-01-28
  */
-public class BalancingDataSourcePublicMetrics extends DataSourcePublicMetrics {
+public class HikariBalancingDataSourcePublicMetrics extends DataSourcePublicMetrics {
 
     @Getter
     private DataSourcePublicMetrics dataSourcePublicMetrics = new DataSourcePublicMetrics();
 
     private final BalancingDataSource balancingDataSource;
 
-    public BalancingDataSourcePublicMetrics(BalancingDataSource balancingDataSource) {
+    public HikariBalancingDataSourcePublicMetrics(BalancingDataSource balancingDataSource) {
         this.balancingDataSource = balancingDataSource;
     }
 
@@ -52,6 +52,7 @@ public class BalancingDataSourcePublicMetrics extends DataSourcePublicMetrics {
     private Pair<String, HikariDataSourcePoolMetadata> splitToNameAndPoolMetadata(NamedFailAwareDataSource namedFailAwareDataSource) {
         HikariDataSourcePoolMetadata poolMetadata = Optional.of(namedFailAwareDataSource)
                                                             .map(NamedFailAwareDataSource::getDataSource)
+                                                            .filter(dataSource -> dataSource instanceof HikariDataSource)
                                                             .map(HikariDataSource.class::cast)
                                                             .map(HikariDataSourcePoolMetadata::new)
                                                             .orElseThrow(IllegalStateException::new);

--- a/src/main/java/io/ankburov/spring/balancing/datasource/metadata/HikariBalancingDataSourcePublicMetrics.java
+++ b/src/main/java/io/ankburov/spring/balancing/datasource/metadata/HikariBalancingDataSourcePublicMetrics.java
@@ -3,8 +3,9 @@ package io.ankburov.spring.balancing.datasource.metadata;
 import com.zaxxer.hikari.HikariDataSource;
 import io.ankburov.spring.balancing.datasource.BalancingDataSource;
 import io.ankburov.spring.balancing.datasource.model.NamedFailAwareDataSource;
-import javafx.util.Pair;
 import lombok.Getter;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.boot.actuate.endpoint.DataSourcePublicMetrics;
 import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.boot.autoconfigure.jdbc.metadata.HikariDataSourcePoolMetadata;
@@ -56,7 +57,7 @@ public class HikariBalancingDataSourcePublicMetrics extends DataSourcePublicMetr
                                                             .map(HikariDataSource.class::cast)
                                                             .map(HikariDataSourcePoolMetadata::new)
                                                             .orElseThrow(IllegalStateException::new);
-        return new Pair<>(namedFailAwareDataSource.getName(), poolMetadata);
+        return new ImmutablePair<>(namedFailAwareDataSource.getName(), poolMetadata);
     }
 
     private Collection<Metric<?>> getMetricsFromDataSourcePoolMetadata(Pair<String, HikariDataSourcePoolMetadata> hikariDataSourcePair) {

--- a/src/main/java/io/ankburov/spring/balancing/datasource/model/ConnectionPoolType.java
+++ b/src/main/java/io/ankburov/spring/balancing/datasource/model/ConnectionPoolType.java
@@ -1,0 +1,10 @@
+package io.ankburov.spring.balancing.datasource.model;
+
+/**
+ * @author ianazarov
+ * (c) RGS
+ * created 2019-02-15
+ */
+public enum ConnectionPoolType {
+    HIKARI
+}

--- a/src/main/java/io/ankburov/spring/balancing/datasource/property/BalancingDataSourceProperties.java
+++ b/src/main/java/io/ankburov/spring/balancing/datasource/property/BalancingDataSourceProperties.java
@@ -2,6 +2,7 @@ package io.ankburov.spring.balancing.datasource.property;
 
 import io.ankburov.spring.balancing.datasource.ignore.IgnoreDataSourceStrategy;
 import io.ankburov.spring.balancing.datasource.model.BalancingType;
+import io.ankburov.spring.balancing.datasource.model.ConnectionPoolType;
 import io.ankburov.spring.balancing.datasource.model.FilteringType;
 import lombok.Getter;
 import lombok.Setter;
@@ -27,6 +28,8 @@ public class BalancingDataSourceProperties {
      * Map of balancing datasources
      */
     private Map<String, ExtendedDataSourceProperties> datasources;
+
+    private ConnectionPoolType connectionPoolType;
 
     /**
      * Order of datasources names (map keys) splitted by a separator

--- a/src/test/groovy/io/ankburov/spring/balancing/datasource/integration/DisabledBalancingDataSourceTest.groovy
+++ b/src/test/groovy/io/ankburov/spring/balancing/datasource/integration/DisabledBalancingDataSourceTest.groovy
@@ -15,7 +15,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @CompileStatic
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = TestConfiguration.class, properties = ["spring.balancing-config.balancing.overrideBalancingDataSource=true"])
+@SpringBootTest(classes = TestConfiguration.class, properties = ["spring.balancing-config.balancing.overrideBalancingDataSource=true",
+        "spring.balancing-config.connectionPoolType=hikari"])
 class DisabledBalancingDataSourceTest {
 
     @Autowired

--- a/src/test/groovy/io/ankburov/spring/balancing/datasource/integration/DisabledBalancingDataSourceTest.groovy
+++ b/src/test/groovy/io/ankburov/spring/balancing/datasource/integration/DisabledBalancingDataSourceTest.groovy
@@ -1,10 +1,16 @@
 package io.ankburov.spring.balancing.datasource.integration
 
 import groovy.transform.CompileStatic
+import io.ankburov.spring.balancing.datasource.BalancingDataSource
 import io.ankburov.spring.balancing.datasource.config.TestConfiguration
+import io.ankburov.spring.balancing.datasource.factory.HikariDataSourceFactory
+import io.ankburov.spring.balancing.datasource.metadata.HikariBalancingDataSourcePublicMetrics
+import org.junit.Assert
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @CompileStatic
@@ -12,7 +18,13 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 @SpringBootTest(classes = TestConfiguration.class, properties = ["spring.balancing-config.balancing.overrideBalancingDataSource=true"])
 class DisabledBalancingDataSourceTest {
 
+    @Autowired
+    ApplicationContext applicationContext
+
     @Test
     void contextLoads() {
+        Assert.assertTrue(applicationContext.getBeanNamesForType(BalancingDataSource).size() == 0)
+        Assert.assertTrue(applicationContext.getBeanNamesForType(HikariDataSourceFactory).size() == 1)
+        Assert.assertTrue(applicationContext.getBeanNamesForType(HikariBalancingDataSourcePublicMetrics).size() == 0)
     }
 }

--- a/src/test/groovy/io/ankburov/spring/balancing/datasource/integration/HikariPublicMetricsTest.groovy
+++ b/src/test/groovy/io/ankburov/spring/balancing/datasource/integration/HikariPublicMetricsTest.groovy
@@ -1,0 +1,45 @@
+package io.ankburov.spring.balancing.datasource.integration
+
+import com.github.dockerjava.api.DockerClient
+import groovy.transform.CompileStatic
+import io.ankburov.spring.balancing.datasource.config.TestConfiguration
+import io.ankburov.spring.balancing.datasource.integration.delegate.MariaDelegate
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.JdbcDatabaseContainer
+
+/**
+ * @author ianazarov
+ * (c) RGS
+ * created 2019-02-14
+ */
+@CompileStatic
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = TestConfiguration.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = ["management.security.enabled=false", "spring.balancing-config.balancing.enableMetricsForDB=hikari"])
+@EnableAutoConfiguration
+class HikariPublicMetricsTest {
+    private static final DockerClient DOCKER = DockerClientFactory.instance().client();
+
+    private static final JdbcDatabaseContainer FIRST_MARIA = new MariaDelegate("first").init()
+    private static final JdbcDatabaseContainer SECOND_MARIA = new MariaDelegate("second").init()
+    @Autowired
+    private TestRestTemplate testRestTemplate
+
+    @Test
+    void testAllDataSourcesAvailable() {
+        def entity = (HashMap<String, String>) testRestTemplate.getForEntity("/metrics", HashMap).getBody()
+        Assertions.assertNotNull(entity.get("datasource.first.active"))
+        Assertions.assertNotNull(entity.get("datasource.first.usage"))
+        Assertions.assertNotNull(entity.get("datasource.second.active"))
+        Assertions.assertNotNull(entity.get("datasource.second.usage"))
+    }
+}


### PR DESCRIPTION
добавлена имплементация сбора метрик для актуаторного /metrics.
Базовая работает с датасорцами которые instanceof tomcat.Datasource или hikari.Datasource.
Поскольку балансирующая имплементация не является одним из базовых типов (хотя и содержит коллекцию hikari.Datasource), то пришлось писать свой велосипед